### PR TITLE
fix(ci): skip SonarQube scan for dependabot PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
       - name: Build CLI
         run: devbox run build-cli
       - name: SonarQube Scan
+        # Skip for dependabot PRs (they don't have access to secrets)
+        if: github.actor != 'dependabot[bot]'
         uses: SonarSource/sonarqube-scan-action@v2
         with:
           args: >


### PR DESCRIPTION
Dependabot PRs fail during CI because they don't have access to the SONAR_TOKEN secret (GitHub restricts secret access for dependabot PRs for security reasons).

This adds a conditional to skip the SonarQube scan step when the PR is created by dependabot[bot]. The rest of the CI checks (formatter, tests, linter, build) will still run and validate the dependency updates.

Changes:
- Add `if: github.actor != 'dependabot[bot]'` to SonarQube Scan step
- SonarQube still runs for all regular PRs and pushes to main
- Dependabot PRs now pass CI successfully

Fixes: Dependabot PR failures due to missing SONAR_TOKEN
Related: GitHub Actions, CI/CD, dependabot integration